### PR TITLE
Refactor ReceiptAnalysis methods

### DIFF
--- a/src/main/java/servlets/ReceiptAnalysis.java
+++ b/src/main/java/servlets/ReceiptAnalysis.java
@@ -44,15 +44,21 @@ public class ReceiptAnalysis {
   /** Returns the text of the image at the requested URL. */
   public static AnalysisResults serveImageText(URL url) throws IOException {
     ByteString imageBytes = readImageBytes(url);
+  
+    String rawText = retrieveText(imageBytes);
+    AnalysisResults results = new AnalysisResults(rawText);
 
-    return retrieveText(imageBytes);
+    return results;
   }
 
   /** Returns the text of the image at the requested blob key. */
   public static AnalysisResults serveImageText(BlobKey blobKey) throws IOException {
     ByteString imageBytes = readImageBytes(blobKey);
+  
+    String rawText = retrieveText(imageBytes);
+    AnalysisResults results = new AnalysisResults(rawText);
 
-    return retrieveText(imageBytes);
+    return results;
   }
 
   /** Reads the image bytes from the URL. */
@@ -92,8 +98,8 @@ public class ReceiptAnalysis {
   }
 
   /** Detects and retrieves text in the provided image. */
-  private static AnalysisResults retrieveText(ByteString imageBytes) throws IOException {
-    String description = "";
+  private static String retrieveText(ByteString imageBytes) throws IOException {
+    String rawText = "";
 
     Image image = Image.newBuilder().setContent(imageBytes).build();
     Feature feature = Feature.newBuilder().setType(Feature.Type.TEXT_DETECTION).build();
@@ -109,10 +115,10 @@ public class ReceiptAnalysis {
       // First element has the entire raw text from the image
       EntityAnnotation annotation = response.getTextAnnotationsList().get(0);
 
-      description = annotation.getDescription();
+      rawText = annotation.getDescription();
     }
 
-    return new AnalysisResults(description);
+    return rawText;
   }
 
   public static class ReceiptAnalysisException extends Exception {

--- a/src/main/java/servlets/ReceiptAnalysis.java
+++ b/src/main/java/servlets/ReceiptAnalysis.java
@@ -44,7 +44,7 @@ public class ReceiptAnalysis {
   /** Returns the text of the image at the requested URL. */
   public static AnalysisResults serveImageText(URL url) throws IOException {
     ByteString imageBytes = readImageBytes(url);
-  
+
     String rawText = retrieveText(imageBytes);
     AnalysisResults results = new AnalysisResults(rawText);
 
@@ -54,7 +54,7 @@ public class ReceiptAnalysis {
   /** Returns the text of the image at the requested blob key. */
   public static AnalysisResults serveImageText(BlobKey blobKey) throws IOException {
     ByteString imageBytes = readImageBytes(blobKey);
-  
+
     String rawText = retrieveText(imageBytes);
     AnalysisResults results = new AnalysisResults(rawText);
 

--- a/src/main/java/servlets/ReceiptAnalysis.java
+++ b/src/main/java/servlets/ReceiptAnalysis.java
@@ -42,7 +42,7 @@ import javax.servlet.http.HttpServletResponse;
  */
 public class ReceiptAnalysis {
   /** Returns the text of the image at the requested URL. */
-  public static AnalysisResults serveImageText(String url) throws IOException {
+  public static AnalysisResults serveImageText(URL url) throws IOException {
     ByteString imageBytes = readImageBytes(url);
 
     return retrieveText(imageBytes);
@@ -56,10 +56,10 @@ public class ReceiptAnalysis {
   }
 
   /** Reads the image bytes from the URL. */
-  private static ByteString readImageBytes(String url) throws IOException {
+  private static ByteString readImageBytes(URL url) throws IOException {
     ByteString imageBytes;
 
-    try (InputStream imageInputStream = new URL(url).openStream()) {
+    try (InputStream imageInputStream = url.openStream()) {
       imageBytes = ByteString.readFrom(imageInputStream);
     }
 

--- a/src/main/java/servlets/ReceiptAnalysisServlet.java
+++ b/src/main/java/servlets/ReceiptAnalysisServlet.java
@@ -17,6 +17,7 @@ package com.google.sps.servlets;
 import com.google.gson.Gson;
 import com.google.sps.data.AnalysisResults;
 import java.io.IOException;
+import java.net.URL;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
@@ -38,7 +39,7 @@ public class ReceiptAnalysisServlet extends HttpServlet {
       return;
     }
 
-    AnalysisResults results = ReceiptAnalysis.serveImageText(url);
+    AnalysisResults results = ReceiptAnalysis.serveImageText(new URL(url));
 
     Gson gson = new Gson();
     response.setContentType("application/json;");

--- a/src/main/java/servlets/UploadReceiptServlet.java
+++ b/src/main/java/servlets/UploadReceiptServlet.java
@@ -177,7 +177,7 @@ public class UploadReceiptServlet extends HttpServlet {
       if (baseUrl.equals(DEV_SERVER_BASE_URL)) {
         results = ReceiptAnalysis.serveImageText(blobKey);
       } else {
-        String absoluteUrl = baseUrl + imageUrl;
+        URL absoluteUrl = new URL(baseUrl + imageUrl);
         results = ReceiptAnalysis.serveImageText(absoluteUrl);
       }
     } catch (IOException e) {


### PR DESCRIPTION
This refactors serveImageText to accept a URL instead of a String in order to make testing simpler, and refactors retrieveText to return a String instead of AnalysisResults in order to make adding more fields to AnalysisResults easier.