### PR TITLE
Replace hard-coded store name and total price fields in receipt entity.

### DIFF
--- a/src/main/java/servlets/UploadReceiptServlet.java
+++ b/src/main/java/servlets/UploadReceiptServlet.java
@@ -129,12 +129,16 @@ public class UploadReceiptServlet extends HttpServlet {
     BlobKey blobKey = getUploadedBlobKey(request, "receipt-image");
     long timestamp = clock.instant().toEpochMilli();
     String label = request.getParameter("label");
+    String store = request.getParameter("store");
+    double price = roundPrice(request.getParameter("price"));
 
     // Populate a receipt entity with the information extracted from the image with Cloud Vision.
     Entity receipt = analyzeReceiptImage(blobKey, request);
     receipt.setProperty("blobKey", blobKey);
     receipt.setProperty("timestamp", timestamp);
     receipt.setProperty("label", label);
+    receipt.setProperty("store", store);
+    receipt.setProperty("price", price);
 
     return receipt;
   }
@@ -179,6 +183,13 @@ public class UploadReceiptServlet extends HttpServlet {
   }
 
   /**
+   * Converts a price string into a double rounded to 2 decimal places.
+   */
+  private static double roundPrice(String price) {
+    return Math.round(Double.parseDouble(price) * 100.0) / 100.0;
+  }
+
+  /**
    * Extracts the raw text from the image with the Cloud Vision API. Returns a receipt
    * entity populated with the extracted fields.
    */
@@ -203,15 +214,9 @@ public class UploadReceiptServlet extends HttpServlet {
       throw new ReceiptAnalysisException("Receipt analysis failed.", e);
     }
 
-    // TODO: Replace hard-coded values using receipt analysis with Cloud Vision.
-    double price = 5.89;
-    String store = "McDonald's";
-
     // Create an entity with a kind of Receipt.
     Entity receipt = new Entity("Receipt");
     receipt.setProperty("imageUrl", imageUrl);
-    receipt.setProperty("price", price);
-    receipt.setProperty("store", store);
     // Text objects wrap around a string of unlimited size while strings are limited to 1500 bytes.
     receipt.setUnindexedProperty("rawText", new Text(results.getRawText()));
 

--- a/src/main/webapp/js/upload.js
+++ b/src/main/webapp/js/upload.js
@@ -32,12 +32,17 @@ async function uploadReceipt(event) {
     return;
   }
 
-  const uploadUrl = await fetchBlobstoreUrl();
+  const uploadUrl = fetchBlobstoreUrl();
   const label = document.getElementById('label-input').value;
+  const store = document.getElementById('store-input').value;
+  const price =
+      convertStringToNumber(document.getElementById('price-input').value);
   const image = fileInput.files[0];
 
   const formData = new FormData();
   formData.append('label', label);
+  formData.append('store', store);
+  formData.append('price', price);
   formData.append('receipt-image', image);
 
   const response = await fetch(uploadUrl, {method: 'POST', body: formData});

--- a/src/test/java/UploadReceiptServletTest.java
+++ b/src/test/java/UploadReceiptServletTest.java
@@ -404,13 +404,7 @@ public final class UploadReceiptServletTest {
     PreparedQuery results = datastore.prepare(query);
     Entity receipt = results.asSingleEntity();
 
-    Assert.assertEquals(receipt.getProperty("imageUrl"), IMAGE_URL);
     Assert.assertEquals(receipt.getProperty("price"), roundedPrice);
-    Assert.assertEquals(receipt.getProperty("store"), STORE);
-    Assert.assertEquals(receipt.getProperty("rawText"), RAW_TEXT);
-    Assert.assertEquals(receipt.getProperty("blobKey"), BLOB_KEY);
-    Assert.assertEquals(receipt.getProperty("timestamp"), PAST_TIMESTAMP);
-    Assert.assertEquals(receipt.getProperty("label"), LABEL);
   }
 
   /**

--- a/src/test/java/UploadReceiptServletTest.java
+++ b/src/test/java/UploadReceiptServletTest.java
@@ -93,8 +93,6 @@ public final class UploadReceiptServletTest {
   private static final String LABEL = "Label";
   private static final Text RAW_TEXT = new Text("raw text");
   private static final double PRICE = 5.89;
-  private static final double PRICE_THREE_DECIMAL_PLACES = 17.236;
-  private static final double PRICE_THREE_DECIMAL_PLACES_ROUNDED = 17.24;
   private static final String STORE = "McDonald's";
   private static final AnalysisResults ANALYSIS_RESULTS = new AnalysisResults(RAW_TEXT.getValue());
 
@@ -330,7 +328,9 @@ public final class UploadReceiptServletTest {
         BLOB_KEY, "image/jpeg", new Date(), VALID_FILENAME, IMAGE_SIZE_1MB, HASH, null);
     when(blobInfoFactory.loadBlobInfo(BLOB_KEY)).thenReturn(blobInfo);
 
-    stubRequestBody(request, LABEL, STORE, PRICE_THREE_DECIMAL_PLACES);
+    double price = 17.236;
+    double roundedPrice = 17.24;
+    stubRequestBody(request, LABEL, STORE, price);
     stubUrlComponents(
         request, LIVE_SERVER_SCHEME, LIVE_SERVER_NAME, LIVE_SERVER_PORT, LIVE_SERVER_CONTEXT_PATH);
 
@@ -347,7 +347,7 @@ public final class UploadReceiptServletTest {
     long timestamp = clock.instant().toEpochMilli();
 
     Assert.assertEquals(receipt.getProperty("imageUrl"), IMAGE_URL);
-    Assert.assertEquals(receipt.getProperty("price"), PRICE_THREE_DECIMAL_PLACES_ROUNDED);
+    Assert.assertEquals(receipt.getProperty("price"), roundedPrice);
     Assert.assertEquals(receipt.getProperty("store"), STORE);
     Assert.assertEquals(receipt.getProperty("rawText"), RAW_TEXT);
     Assert.assertEquals(receipt.getProperty("blobKey"), BLOB_KEY);

--- a/src/test/java/UploadReceiptServletTest.java
+++ b/src/test/java/UploadReceiptServletTest.java
@@ -167,10 +167,7 @@ public final class UploadReceiptServletTest {
         BLOB_KEY, "image/jpeg", new Date(), VALID_FILENAME, IMAGE_SIZE_1MB, HASH, null);
     when(blobInfoFactory.loadBlobInfo(BLOB_KEY)).thenReturn(blobInfo);
 
-    when(request.getParameter("label")).thenReturn(LABEL);
-    when(request.getParameter("store")).thenReturn(STORE);
-    when(request.getParameter("price")).thenReturn(String.valueOf(PRICE));
-
+    stubRequestBody(request, LABEL, STORE, PRICE);
     stubUrlComponents(
         request, LIVE_SERVER_SCHEME, LIVE_SERVER_NAME, LIVE_SERVER_PORT, LIVE_SERVER_CONTEXT_PATH);
 
@@ -205,10 +202,7 @@ public final class UploadReceiptServletTest {
         BLOB_KEY, "image/jpeg", new Date(), VALID_FILENAME, IMAGE_SIZE_1MB, HASH, null);
     when(blobInfoFactory.loadBlobInfo(BLOB_KEY)).thenReturn(blobInfo);
 
-    when(request.getParameter("label")).thenReturn(LABEL);
-    when(request.getParameter("store")).thenReturn(STORE);
-    when(request.getParameter("price")).thenReturn(String.valueOf(PRICE));
-
+    stubRequestBody(request, LABEL, STORE, PRICE);
     stubUrlComponents(
         request, DEV_SERVER_SCHEME, DEV_SERVER_NAME, DEV_SERVER_PORT, DEV_SERVER_CONTEXT_PATH);
 
@@ -309,10 +303,7 @@ public final class UploadReceiptServletTest {
         BLOB_KEY, "image/jpeg", new Date(), VALID_FILENAME, IMAGE_SIZE_1MB, HASH, null);
     when(blobInfoFactory.loadBlobInfo(BLOB_KEY)).thenReturn(blobInfo);
 
-    when(request.getParameter("label")).thenReturn(LABEL);
-    when(request.getParameter("store")).thenReturn(STORE);
-    when(request.getParameter("price")).thenReturn(String.valueOf(PRICE));
-
+    stubRequestBody(request, LABEL, STORE, PRICE);
     stubUrlComponents(
         request, LIVE_SERVER_SCHEME, LIVE_SERVER_NAME, LIVE_SERVER_PORT, LIVE_SERVER_CONTEXT_PATH);
 
@@ -339,10 +330,7 @@ public final class UploadReceiptServletTest {
         BLOB_KEY, "image/jpeg", new Date(), VALID_FILENAME, IMAGE_SIZE_1MB, HASH, null);
     when(blobInfoFactory.loadBlobInfo(BLOB_KEY)).thenReturn(blobInfo);
 
-    when(request.getParameter("label")).thenReturn(LABEL);
-    when(request.getParameter("store")).thenReturn(STORE);
-    when(request.getParameter("price")).thenReturn(String.valueOf(PRICE_THREE_DECIMAL_PLACES));
-
+    stubRequestBody(request, LABEL, STORE, PRICE_THREE_DECIMAL_PLACES);
     stubUrlComponents(
         request, LIVE_SERVER_SCHEME, LIVE_SERVER_NAME, LIVE_SERVER_PORT, LIVE_SERVER_CONTEXT_PATH);
 
@@ -365,6 +353,16 @@ public final class UploadReceiptServletTest {
     Assert.assertEquals(receipt.getProperty("blobKey"), BLOB_KEY);
     Assert.assertEquals(receipt.getProperty("timestamp"), timestamp);
     Assert.assertEquals(receipt.getProperty("label"), LABEL);
+  }
+
+  /**
+   * Stubs the request with the given label, store, and price parameters.
+   */
+  private void stubRequestBody(
+      HttpServletRequest request, String label, String store, double price) {
+    when(request.getParameter("label")).thenReturn(label);
+    when(request.getParameter("store")).thenReturn(store);
+    when(request.getParameter("price")).thenReturn(String.valueOf(price));
   }
 
   /**

--- a/src/test/java/UploadReceiptServletTest.java
+++ b/src/test/java/UploadReceiptServletTest.java
@@ -385,10 +385,6 @@ public final class UploadReceiptServletTest {
   public void doPostRoundPrice() throws IOException {
     helper.setEnvIsLoggedIn(true);
 
-    StringWriter stringWriter = new StringWriter();
-    PrintWriter writer = new PrintWriter(stringWriter);
-    when(response.getWriter()).thenReturn(writer);
-
     createMockBlob(request, VALID_CONTENT_TYPE, VALID_FILENAME, IMAGE_SIZE_1MB);
 
     double price = 17.236;

--- a/src/test/java/UploadReceiptServletTest.java
+++ b/src/test/java/UploadReceiptServletTest.java
@@ -171,11 +171,8 @@ public final class UploadReceiptServletTest {
     when(request.getParameter("store")).thenReturn(STORE);
     when(request.getParameter("price")).thenReturn(String.valueOf(PRICE));
 
-    // Stub request with URL components.
-    when(request.getScheme()).thenReturn(LIVE_SERVER_SCHEME);
-    when(request.getServerName()).thenReturn(LIVE_SERVER_NAME);
-    when(request.getServerPort()).thenReturn(LIVE_SERVER_PORT);
-    when(request.getContextPath()).thenReturn(LIVE_SERVER_CONTEXT_PATH);
+    stubUrlComponents(
+        request, LIVE_SERVER_SCHEME, LIVE_SERVER_NAME, LIVE_SERVER_PORT, LIVE_SERVER_CONTEXT_PATH);
 
     // Mock receipt analysis.
     mockStatic(ReceiptAnalysis.class);
@@ -212,11 +209,8 @@ public final class UploadReceiptServletTest {
     when(request.getParameter("store")).thenReturn(STORE);
     when(request.getParameter("price")).thenReturn(String.valueOf(PRICE));
 
-    // Stub request with dev server URL components.
-    when(request.getScheme()).thenReturn(DEV_SERVER_SCHEME);
-    when(request.getServerName()).thenReturn(DEV_SERVER_NAME);
-    when(request.getServerPort()).thenReturn(DEV_SERVER_PORT);
-    when(request.getContextPath()).thenReturn(DEV_SERVER_CONTEXT_PATH);
+    stubUrlComponents(
+        request, DEV_SERVER_SCHEME, DEV_SERVER_NAME, DEV_SERVER_PORT, DEV_SERVER_CONTEXT_PATH);
 
     // Mock receipt analysis.
     mockStatic(ReceiptAnalysis.class);
@@ -319,11 +313,8 @@ public final class UploadReceiptServletTest {
     when(request.getParameter("store")).thenReturn(STORE);
     when(request.getParameter("price")).thenReturn(String.valueOf(PRICE));
 
-    // Stub request with URL components.
-    when(request.getScheme()).thenReturn(LIVE_SERVER_SCHEME);
-    when(request.getServerName()).thenReturn(LIVE_SERVER_NAME);
-    when(request.getServerPort()).thenReturn(LIVE_SERVER_PORT);
-    when(request.getContextPath()).thenReturn(LIVE_SERVER_CONTEXT_PATH);
+    stubUrlComponents(
+        request, LIVE_SERVER_SCHEME, LIVE_SERVER_NAME, LIVE_SERVER_PORT, LIVE_SERVER_CONTEXT_PATH);
 
     // Mock receipt analysis exception.
     mockStatic(ReceiptAnalysis.class);
@@ -352,11 +343,8 @@ public final class UploadReceiptServletTest {
     when(request.getParameter("store")).thenReturn(STORE);
     when(request.getParameter("price")).thenReturn(String.valueOf(PRICE_THREE_DECIMAL_PLACES));
 
-    // Stub request with URL components.
-    when(request.getScheme()).thenReturn(LIVE_SERVER_SCHEME);
-    when(request.getServerName()).thenReturn(LIVE_SERVER_NAME);
-    when(request.getServerPort()).thenReturn(LIVE_SERVER_PORT);
-    when(request.getContextPath()).thenReturn(LIVE_SERVER_CONTEXT_PATH);
+    stubUrlComponents(
+        request, LIVE_SERVER_SCHEME, LIVE_SERVER_NAME, LIVE_SERVER_PORT, LIVE_SERVER_CONTEXT_PATH);
 
     // Mock receipt analysis.
     mockStatic(ReceiptAnalysis.class);
@@ -377,5 +365,16 @@ public final class UploadReceiptServletTest {
     Assert.assertEquals(receipt.getProperty("blobKey"), BLOB_KEY);
     Assert.assertEquals(receipt.getProperty("timestamp"), timestamp);
     Assert.assertEquals(receipt.getProperty("label"), LABEL);
+  }
+
+  /**
+   * Stubs the request with the given scheme, server name, port, and context path URL components.
+   */
+  private void stubUrlComponents(
+      HttpServletRequest request, String scheme, String serverName, int port, String contextPath) {
+    when(request.getScheme()).thenReturn(scheme);
+    when(request.getServerName()).thenReturn(serverName);
+    when(request.getServerPort()).thenReturn(port);
+    when(request.getContextPath()).thenReturn(contextPath);
   }
 }


### PR DESCRIPTION
- Send store name and total price from the upload form to the upload servlet
- Insert fields in Datastore entity
- Update upload servlet unit tests
- Add unit test for rounding total price