### PR TITLE
Use the user-inputted transaction date as the receipt timestamp.

### DIFF
--- a/src/main/java/servlets/UploadReceiptServlet.java
+++ b/src/main/java/servlets/UploadReceiptServlet.java
@@ -127,7 +127,7 @@ public class UploadReceiptServlet extends HttpServlet {
   private Entity createReceiptEntity(HttpServletRequest request)
       throws FileNotSelectedException, InvalidFileException, InvalidDateException,
              ReceiptAnalysisException {
-    long timestamp = getDate(request);
+    long timestamp = getTimestamp(request);
     BlobKey blobKey = getUploadedBlobKey(request, "receipt-image");
     String label = request.getParameter("label");
 
@@ -141,10 +141,10 @@ public class UploadReceiptServlet extends HttpServlet {
   }
 
   /**
-   * Converts the date parameter from the request to a long and verifies that the date is in the
-   * past.
+   * Converts the date parameter from the request to a timestamp and verifies that the date is in
+   * the past.
    */
-  private long getDate(HttpServletRequest request) throws InvalidDateException {
+  private long getTimestamp(HttpServletRequest request) throws InvalidDateException {
     long currentTimestamp = clock.instant().toEpochMilli();
     long transactionTimestamp;
 

--- a/src/main/java/servlets/UploadReceiptServlet.java
+++ b/src/main/java/servlets/UploadReceiptServlet.java
@@ -151,7 +151,7 @@ public class UploadReceiptServlet extends HttpServlet {
     try {
       transactionTimestamp = Long.parseLong(request.getParameter("date"));
     } catch (NumberFormatException e) {
-      throw new InvalidDateException("Transaction date must a long.");
+      throw new InvalidDateException("Transaction date must be a long.");
     }
 
     if (transactionTimestamp > currentTimestamp) {

--- a/src/test/java/UploadReceiptServletTest.java
+++ b/src/test/java/UploadReceiptServletTest.java
@@ -162,14 +162,7 @@ public final class UploadReceiptServletTest {
 
   @Test
   public void doPostUploadsReceiptToDatastoreLiveServer() throws IOException {
-    // Add mock blob to Blobstore.
-    Map<String, List<BlobKey>> blobs = new HashMap<>();
-    blobs.put("receipt-image", Arrays.asList(BLOB_KEY));
-    when(blobstoreService.getUploads(request)).thenReturn(blobs);
-    BlobInfo blobInfo = new BlobInfo(
-        BLOB_KEY, "image/jpeg", new Date(), VALID_FILENAME, IMAGE_SIZE_1MB, HASH, null);
-    when(blobInfoFactory.loadBlobInfo(BLOB_KEY)).thenReturn(blobInfo);
-
+    createMockBlob(request, "image/jpeg", VALID_FILENAME, IMAGE_SIZE_1MB);
     when(request.getParameter("label")).thenReturn(LABEL);
 
     long timestamp = clock.millis() - 1234;
@@ -203,14 +196,7 @@ public final class UploadReceiptServletTest {
 
   @Test
   public void doPostUploadsReceiptToDatastoreDevServer() throws IOException {
-    // Add mock blob to Blobstore.
-    Map<String, List<BlobKey>> blobs = new HashMap<>();
-    blobs.put("receipt-image", Arrays.asList(BLOB_KEY));
-    when(blobstoreService.getUploads(request)).thenReturn(blobs);
-    BlobInfo blobInfo = new BlobInfo(
-        BLOB_KEY, "image/jpeg", new Date(), VALID_FILENAME, IMAGE_SIZE_1MB, HASH, null);
-    when(blobInfoFactory.loadBlobInfo(BLOB_KEY)).thenReturn(blobInfo);
-
+    createMockBlob(request, "image/jpeg", VALID_FILENAME, IMAGE_SIZE_1MB);
     when(request.getParameter("label")).thenReturn(LABEL);
 
     long timestamp = clock.millis() - 1234;
@@ -248,13 +234,7 @@ public final class UploadReceiptServletTest {
     PrintWriter writer = new PrintWriter(stringWriter);
     when(response.getWriter()).thenReturn(writer);
 
-    // Add mock blob of size 0 to Blobstore.
-    Map<String, List<BlobKey>> blobs = new HashMap<>();
-    blobs.put("receipt-image", Arrays.asList(BLOB_KEY));
-    when(blobstoreService.getUploads(request)).thenReturn(blobs);
-    BlobInfo blobInfo = new BlobInfo(
-        BLOB_KEY, "image/jpeg", new Date(), VALID_FILENAME, IMAGE_SIZE_0MB, HASH, null);
-    when(blobInfoFactory.loadBlobInfo(BLOB_KEY)).thenReturn(blobInfo);
+    createMockBlob(request, "image/jpeg", VALID_FILENAME, IMAGE_SIZE_0MB);
 
     long timestamp = clock.millis() - 1234;
     String date = Long.toString(timestamp);
@@ -295,13 +275,7 @@ public final class UploadReceiptServletTest {
     PrintWriter writer = new PrintWriter(stringWriter);
     when(response.getWriter()).thenReturn(writer);
 
-    // Add mock blob with PNG filename to Blobstore.
-    Map<String, List<BlobKey>> blobs = new HashMap<>();
-    blobs.put("receipt-image", Arrays.asList(BLOB_KEY));
-    when(blobstoreService.getUploads(request)).thenReturn(blobs);
-    BlobInfo blobInfo = new BlobInfo(
-        BLOB_KEY, "image/png", new Date(), INVALID_FILENAME, IMAGE_SIZE_1MB, HASH, null);
-    when(blobInfoFactory.loadBlobInfo(BLOB_KEY)).thenReturn(blobInfo);
+    createMockBlob(request, "image/png", INVALID_FILENAME, IMAGE_SIZE_1MB);
 
     long timestamp = clock.millis() - 1234;
     String date = Long.toString(timestamp);
@@ -353,13 +327,7 @@ public final class UploadReceiptServletTest {
     PrintWriter writer = new PrintWriter(stringWriter);
     when(response.getWriter()).thenReturn(writer);
 
-    // Add mock blob to Blobstore.
-    Map<String, List<BlobKey>> blobs = new HashMap<>();
-    blobs.put("receipt-image", Arrays.asList(BLOB_KEY));
-    when(blobstoreService.getUploads(request)).thenReturn(blobs);
-    BlobInfo blobInfo = new BlobInfo(
-        BLOB_KEY, "image/jpeg", new Date(), VALID_FILENAME, IMAGE_SIZE_1MB, HASH, null);
-    when(blobInfoFactory.loadBlobInfo(BLOB_KEY)).thenReturn(blobInfo);
+    createMockBlob(request, "image/jpeg", VALID_FILENAME, IMAGE_SIZE_1MB);
 
     when(request.getParameter("label")).thenReturn(LABEL);
 
@@ -384,5 +352,17 @@ public final class UploadReceiptServletTest {
     verify(response).setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
 
     verify(blobstoreService).delete(BLOB_KEY);
+  }
+
+  /**
+   * Adds a mock blob with the given content type, filename, and size to the mocked Blobstore.
+   */
+  private void createMockBlob(
+      HttpServletRequest request, String contentType, String filename, long size) {
+    Map<String, List<BlobKey>> blobs = new HashMap<>();
+    blobs.put("receipt-image", Arrays.asList(BLOB_KEY));
+    when(blobstoreService.getUploads(request)).thenReturn(blobs);
+    BlobInfo blobInfo = new BlobInfo(BLOB_KEY, contentType, new Date(), filename, size, HASH, null);
+    when(blobInfoFactory.loadBlobInfo(BLOB_KEY)).thenReturn(blobInfo);
   }
 }

--- a/src/test/java/UploadReceiptServletTest.java
+++ b/src/test/java/UploadReceiptServletTest.java
@@ -94,6 +94,8 @@ public final class UploadReceiptServletTest {
   private static final BlobKey BLOB_KEY = new BlobKey("blobKey");
   private static final String VALID_FILENAME = "image.jpg";
   private static final String INVALID_FILENAME = "image.png";
+  private static final String VALID_CONTENT_TYPE = "image/jpeg";
+  private static final String INVALID_CONTENT_TYPE = "image/png";
   private static final long IMAGE_SIZE_1MB = 1024 * 1024;
   private static final long IMAGE_SIZE_0MB = 0;
   private static final String HASH = "35454B055CC325EA1AF2126E27707052";
@@ -166,7 +168,7 @@ public final class UploadReceiptServletTest {
 
   @Test
   public void doPostUploadsReceiptToDatastoreLiveServer() throws IOException {
-    createMockBlob(request, "image/jpeg", VALID_FILENAME, IMAGE_SIZE_1MB);
+    createMockBlob(request, VALID_CONTENT_TYPE, VALID_FILENAME, IMAGE_SIZE_1MB);
     when(request.getParameter("label")).thenReturn(LABEL);
     setTransactionDate(request, PAST_TIMESTAMP);
 
@@ -197,7 +199,7 @@ public final class UploadReceiptServletTest {
 
   @Test
   public void doPostUploadsReceiptToDatastoreDevServer() throws IOException {
-    createMockBlob(request, "image/jpeg", VALID_FILENAME, IMAGE_SIZE_1MB);
+    createMockBlob(request, VALID_CONTENT_TYPE, VALID_FILENAME, IMAGE_SIZE_1MB);
     when(request.getParameter("label")).thenReturn(LABEL);
     setTransactionDate(request, PAST_TIMESTAMP);
 
@@ -232,7 +234,7 @@ public final class UploadReceiptServletTest {
     PrintWriter writer = new PrintWriter(stringWriter);
     when(response.getWriter()).thenReturn(writer);
 
-    createMockBlob(request, "image/jpeg", VALID_FILENAME, IMAGE_SIZE_0MB);
+    createMockBlob(request, VALID_CONTENT_TYPE, VALID_FILENAME, IMAGE_SIZE_0MB);
     setTransactionDate(request, PAST_TIMESTAMP);
 
     servlet.doPost(request, response);
@@ -268,7 +270,7 @@ public final class UploadReceiptServletTest {
     PrintWriter writer = new PrintWriter(stringWriter);
     when(response.getWriter()).thenReturn(writer);
 
-    createMockBlob(request, "image/png", INVALID_FILENAME, IMAGE_SIZE_1MB);
+    createMockBlob(request, INVALID_CONTENT_TYPE, INVALID_FILENAME, IMAGE_SIZE_1MB);
     setTransactionDate(request, PAST_TIMESTAMP);
 
     servlet.doPost(request, response);
@@ -316,7 +318,7 @@ public final class UploadReceiptServletTest {
     PrintWriter writer = new PrintWriter(stringWriter);
     when(response.getWriter()).thenReturn(writer);
 
-    createMockBlob(request, "image/jpeg", VALID_FILENAME, IMAGE_SIZE_1MB);
+    createMockBlob(request, VALID_CONTENT_TYPE, VALID_FILENAME, IMAGE_SIZE_1MB);
     when(request.getParameter("label")).thenReturn(LABEL);
     setTransactionDate(request, PAST_TIMESTAMP);
 

--- a/src/test/java/UploadReceiptServletTest.java
+++ b/src/test/java/UploadReceiptServletTest.java
@@ -78,7 +78,7 @@ public final class UploadReceiptServletTest {
   private static final String INVALID_DATE_RANGE_WARNING =
       "com.google.sps.servlets.UploadReceiptServlet$InvalidDateException: Transaction date must be in the past.";
   private static final String INVALID_DATE_FORMAT_WARNING =
-      "com.google.sps.servlets.UploadReceiptServlet$InvalidDateException: Transaction date must a long.";
+      "com.google.sps.servlets.UploadReceiptServlet$InvalidDateException: Transaction date must be a long.";
   private static final String RECEIPT_ANALYSIS_FAILED_WARNING =
       "com.google.sps.servlets.ReceiptAnalysis$ReceiptAnalysisException: Receipt analysis failed.";
 


### PR DESCRIPTION
- Insert transaction date parameter in Datastore receipt entity
- Add exception for invalid date parameter
- Update upload unit tests with date parameter
- Add unit tests for invalid dates