### PR TITLE
Handle bad response from Cloud Vision API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,12 @@
       <version>29.0-jre</version>
     </dependency>
 
+    <dependency>
+      <groupId>com.google.api</groupId>
+      <artifactId>gax</artifactId>
+      <version>1.57.1</version>
+    </dependency>
+
     <!-- Test Dependencies -->
     <dependency>
       <groupId>org.junit.jupiter</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,13 @@
 
     <!-- Test Dependencies -->
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <version>5.4.0</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.12</version>

--- a/pom.xml
+++ b/pom.xml
@@ -94,56 +94,6 @@
       <version>1.9.80</version>
       <scope>test</scope>
     </dependency>
-
-    <!-- Test Dependencies -->
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>4.12</version>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-module-junit4</artifactId>
-      <version>1.7.4</version>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-api-mockito2</artifactId>
-      <version>1.7.4</version>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>com.google.appengine</groupId>
-      <artifactId>appengine-testing</artifactId>
-      <version>1.9.64</version>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>com.google.appengine</groupId>
-      <artifactId>appengine-api-labs</artifactId>
-      <version>1.9.80</version>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>com.google.appengine</groupId>
-      <artifactId>appengine-api-stubs</artifactId>
-      <version>1.9.80</version>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>com.google.appengine</groupId>
-      <artifactId>appengine-tools-sdk</artifactId>
-      <version>1.9.80</version>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/src/main/java/servlets/ReceiptAnalysis.java
+++ b/src/main/java/servlets/ReceiptAnalysis.java
@@ -14,6 +14,7 @@
 
 package com.google.sps.servlets;
 
+import com.google.api.gax.rpc.ApiException;
 import com.google.appengine.api.blobstore.BlobInfo;
 import com.google.appengine.api.blobstore.BlobInfoFactory;
 import com.google.appengine.api.blobstore.BlobKey;
@@ -130,6 +131,8 @@ public class ReceiptAnalysis {
       EntityAnnotation annotation = response.getTextAnnotationsList().get(0);
 
       rawText = annotation.getDescription();
+    } catch (ApiException e) {
+      throw new ReceiptAnalysisException("Image annotation request failed.", e);
     }
 
     return rawText;

--- a/src/main/java/servlets/ReceiptAnalysis.java
+++ b/src/main/java/servlets/ReceiptAnalysis.java
@@ -111,7 +111,6 @@ public class ReceiptAnalysis {
     ImmutableList<AnnotateImageRequest> requests = ImmutableList.of(request);
 
     try (ImageAnnotatorClient client = ImageAnnotatorClient.create()) {
-      // TODO: Throw custom exception from PR #12 if response has an error or is missing
       BatchAnnotateImagesResponse batchResponse = client.batchAnnotateImages(requests);
 
       if (batchResponse.getResponsesList().isEmpty()) {
@@ -122,6 +121,9 @@ public class ReceiptAnalysis {
 
       if (response.hasError()) {
         throw new ReceiptAnalysisException("Received image annotation response with error.");
+      } else if (response.getTextAnnotationsList().isEmpty()) {
+        throw new ReceiptAnalysisException(
+            "Received image annotation response without text annotations.");
       }
 
       // First element has the entire raw text from the image

--- a/src/main/java/servlets/ReceiptAnalysis.java
+++ b/src/main/java/servlets/ReceiptAnalysis.java
@@ -120,6 +120,10 @@ public class ReceiptAnalysis {
 
       AnnotateImageResponse response = Iterables.getOnlyElement(batchResponse.getResponsesList());
 
+      if (response.hasError()) {
+        throw new ReceiptAnalysisException("Received image annotation response with error.");
+      }
+
       // First element has the entire raw text from the image
       EntityAnnotation annotation = response.getTextAnnotationsList().get(0);
 

--- a/src/main/java/servlets/ReceiptAnalysisServlet.java
+++ b/src/main/java/servlets/ReceiptAnalysisServlet.java
@@ -16,6 +16,7 @@ package com.google.sps.servlets;
 
 import com.google.gson.Gson;
 import com.google.sps.data.AnalysisResults;
+import com.google.sps.servlets.ReceiptAnalysis.ReceiptAnalysisException;
 import java.io.IOException;
 import java.net.URL;
 import javax.servlet.annotation.WebServlet;
@@ -33,13 +34,20 @@ public class ReceiptAnalysisServlet extends HttpServlet {
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
     String url = request.getParameter("url");
+    AnalysisResults results = null;
 
     // Ignore requests that don't specify a URL
     if (url == null) {
       return;
     }
 
-    AnalysisResults results = ReceiptAnalysis.serveImageText(new URL(url));
+    try {
+      results = ReceiptAnalysis.serveImageText(new URL(url));
+    } catch (ReceiptAnalysisException e) {
+      response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+      response.getWriter().println(e.toString());
+      return;
+    }
 
     Gson gson = new Gson();
     response.setContentType("application/json;");

--- a/src/test/java/ReceiptAnalysisTest.java
+++ b/src/test/java/ReceiptAnalysisTest.java
@@ -50,6 +50,8 @@ public final class ReceiptAnalysisTest {
       "Received empty batch image annotation response.";
   private static final String RESPONSE_ERROR_WARNING =
       "Received image annotation response with error.";
+  private static final String EMPTY_TEXT_ANNOTATIONS_LIST_WARNING =
+      "Received image annotation response without text annotations.";
 
   private static final ByteString IMAGE_BYTES = ByteString.copyFromUtf8("byte string");
   private static final String RAW_TEXT = "raw text";
@@ -126,6 +128,29 @@ public final class ReceiptAnalysisTest {
 
     expectedException.expect(ReceiptAnalysisException.class);
     expectedException.expectMessage(RESPONSE_ERROR_WARNING);
+
+    ReceiptAnalysis.serveImageText(url);
+  }
+
+  @Test
+  public void serveImageTextThrowsIfEmptyTextAnnotationsList()
+      throws IOException, ReceiptAnalysisException {
+    URL url = mock(URL.class);
+    InputStream inputStream = new ByteArrayInputStream(IMAGE_BYTES.toByteArray());
+    when(url.openStream()).thenReturn(inputStream);
+
+    ImageAnnotatorClient client = mock(ImageAnnotatorClient.class);
+    mockStatic(ImageAnnotatorClient.class);
+    when(ImageAnnotatorClient.create()).thenReturn(client);
+
+    AnnotateImageResponse response = AnnotateImageResponse.newBuilder().build();
+    BatchAnnotateImagesResponse batchResponse =
+        BatchAnnotateImagesResponse.newBuilder().addResponses(response).build();
+    when(client.batchAnnotateImages(Mockito.<AnnotateImageRequest>anyList()))
+        .thenReturn(batchResponse);
+
+    expectedException.expect(ReceiptAnalysisException.class);
+    expectedException.expectMessage(EMPTY_TEXT_ANNOTATIONS_LIST_WARNING);
 
     ReceiptAnalysis.serveImageText(url);
   }

--- a/src/test/java/ReceiptAnalysisTest.java
+++ b/src/test/java/ReceiptAnalysisTest.java
@@ -39,9 +39,8 @@ import java.io.InputStream;
 import java.net.URL;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Assertions;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
@@ -65,8 +64,6 @@ public final class ReceiptAnalysisTest {
   public void setUp() {
     MockitoAnnotations.initMocks(this);
   }
-
-  @Rule public ExpectedException expectedException = ExpectedException.none();
 
   @Test
   public void serveImageTextUrlReturnsAnalysisResults()
@@ -113,10 +110,10 @@ public final class ReceiptAnalysisTest {
     when(client.batchAnnotateImages(Mockito.<AnnotateImageRequest>anyList()))
         .thenReturn(batchResponse);
 
-    expectedException.expect(ReceiptAnalysisException.class);
-    expectedException.expectMessage(EMPTY_BATCH_RESPONSE_WARNING);
+    ReceiptAnalysisException exception = Assertions.assertThrows(
+        ReceiptAnalysisException.class, () -> { ReceiptAnalysis.serveImageText(url); });
 
-    ReceiptAnalysis.serveImageText(url);
+    Assert.assertEquals(EMPTY_BATCH_RESPONSE_WARNING, exception.getMessage());
   }
 
   @Test
@@ -137,10 +134,10 @@ public final class ReceiptAnalysisTest {
     when(client.batchAnnotateImages(Mockito.<AnnotateImageRequest>anyList()))
         .thenReturn(batchResponse);
 
-    expectedException.expect(ReceiptAnalysisException.class);
-    expectedException.expectMessage(RESPONSE_ERROR_WARNING);
+    ReceiptAnalysisException exception = Assertions.assertThrows(
+        ReceiptAnalysisException.class, () -> { ReceiptAnalysis.serveImageText(url); });
 
-    ReceiptAnalysis.serveImageText(url);
+    Assert.assertEquals(RESPONSE_ERROR_WARNING, exception.getMessage());
   }
 
   @Test
@@ -160,9 +157,9 @@ public final class ReceiptAnalysisTest {
     when(client.batchAnnotateImages(Mockito.<AnnotateImageRequest>anyList()))
         .thenReturn(batchResponse);
 
-    expectedException.expect(ReceiptAnalysisException.class);
-    expectedException.expectMessage(EMPTY_TEXT_ANNOTATIONS_LIST_WARNING);
+    ReceiptAnalysisException exception = Assertions.assertThrows(
+        ReceiptAnalysisException.class, () -> { ReceiptAnalysis.serveImageText(url); });
 
-    ReceiptAnalysis.serveImageText(url);
+    Assert.assertEquals(EMPTY_TEXT_ANNOTATIONS_LIST_WARNING, exception.getMessage());
   }
 }

--- a/src/test/java/UploadReceiptServletTest.java
+++ b/src/test/java/UploadReceiptServletTest.java
@@ -389,7 +389,7 @@ public final class UploadReceiptServletTest {
   }
 
   @Test
-  public void doPostRoundPrice() throws IOException {
+  public void doPostRoundPrice() throws IOException, ReceiptAnalysisException {
     helper.setEnvIsLoggedIn(true);
 
     StringWriter stringWriter = new StringWriter();

--- a/src/test/java/UploadReceiptServletTest.java
+++ b/src/test/java/UploadReceiptServletTest.java
@@ -40,6 +40,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.gson.Gson;
 import com.google.sps.data.AnalysisResults;
 import com.google.sps.servlets.ReceiptAnalysis;
+import com.google.sps.servlets.ReceiptAnalysis.ReceiptAnalysisException;
 import com.google.sps.servlets.UploadReceiptServlet;
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -181,7 +182,8 @@ public final class UploadReceiptServletTest {
   }
 
   @Test
-  public void doPostUploadsReceiptToDatastoreLiveServer() throws IOException {
+  public void doPostUploadsReceiptToDatastoreLiveServer()
+      throws IOException, ReceiptAnalysisException {
     helper.setEnvIsLoggedIn(true);
     createMockBlob(request, VALID_CONTENT_TYPE, VALID_FILENAME, IMAGE_SIZE_1MB);
 
@@ -216,7 +218,8 @@ public final class UploadReceiptServletTest {
   }
 
   @Test
-  public void doPostUploadsReceiptToDatastoreDevServer() throws IOException {
+  public void doPostUploadsReceiptToDatastoreDevServer()
+      throws IOException, ReceiptAnalysisException {
     helper.setEnvIsLoggedIn(true);
     createMockBlob(request, VALID_CONTENT_TYPE, VALID_FILENAME, IMAGE_SIZE_1MB);
 
@@ -363,7 +366,7 @@ public final class UploadReceiptServletTest {
   }
 
   @Test
-  public void doPostThrowsIfReceiptAnalysisFails() throws IOException {
+  public void doPostThrowsIfReceiptAnalysisFails() throws IOException, ReceiptAnalysisException {
     helper.setEnvIsLoggedIn(true);
 
     StringWriter stringWriter = new StringWriter();


### PR DESCRIPTION
Throw an exception for:
* empty batch response
* response with error
* empty text annotations list