### PR TITLE
Redirect to receipt analysis page after uploading receipt.

### DIFF
--- a/src/main/java/servlets/UploadReceiptServlet.java
+++ b/src/main/java/servlets/UploadReceiptServlet.java
@@ -27,6 +27,7 @@ import com.google.appengine.api.datastore.Entity;
 import com.google.appengine.api.datastore.Text;
 import com.google.appengine.api.users.UserService;
 import com.google.appengine.api.users.UserServiceFactory;
+import com.google.gson.Gson;
 import com.google.sps.data.AnalysisResults;
 import com.google.sps.servlets.ReceiptAnalysis.ReceiptAnalysisException;
 import java.io.IOException;
@@ -105,7 +106,7 @@ public class UploadReceiptServlet extends HttpServlet {
   /**
    * When the user submits the upload form, Blobstore processes the image and then forwards the
    * request to this servlet, which analyzes the receipt image and inserts information
-   * about the receipt into Datastore.
+   * about the receipt into Datastore. The JSON response contains the receipt that was added.
    */
   @Override
   public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
@@ -132,6 +133,13 @@ public class UploadReceiptServlet extends HttpServlet {
 
     // Store the receipt entity in Datastore.
     datastore.put(receipt);
+
+    // Convert the receipt to JSON.
+    String json = new Gson().toJson(receipt);
+
+    // Send the JSON as the response.
+    response.setContentType("application/json;");
+    response.getWriter().println(json);
   }
 
   /**

--- a/src/main/webapp/js/upload.js
+++ b/src/main/webapp/js/upload.js
@@ -53,10 +53,15 @@ async function uploadReceipt(event) {
   }
 
   const json = (await response.json()).propertyMap;
+  const params = new URLSearchParams();
+  params.append('categories', json.categories);
+  params.append('image-url', json.imageUrl);
+  params.append('price', json.price);
+  params.append('store', json.store);
+  params.append('timestamp', json.timestamp);
+
   // Redirect to the receipt analysis page.
-  window.location.href = `/receipt-analysis.html?categories=` +
-      `${json.categories}&image-url=${json.imageUrl}` +
-      `&price=${json.price}&store=${json.store}&timestamp=${json.timestamp}`;
+  window.location.href = `/receipt-analysis.html?${params.toString()}`;
 }
 
 /**

--- a/src/main/webapp/js/upload.js
+++ b/src/main/webapp/js/upload.js
@@ -20,7 +20,8 @@ function cancelUpload() {
 }
 
 /**
- * Sends a request to add a receipt to Blobstore.
+ * Sends a request to add a receipt to Blobstore then redirects to the receipt
+ * analysis page.
  */
 async function uploadReceipt(event) {
   // Prevent the default action of reloading the page on form submission.
@@ -51,8 +52,11 @@ async function uploadReceipt(event) {
     return;
   }
 
-  // TODO: Redirect to receipt analysis page for MVP
-  window.location.href = '/';
+  const json = (await response.json()).propertyMap;
+  // Redirect to the receipt analysis page.
+  window.location.href = `/receipt-analysis.html?categories=${
+      json.categories}&image-url=${json.imageUrl}&price=${json.price}&store=${
+      json.store}&timestamp=${json.timestamp}`;
 }
 
 /**

--- a/src/main/webapp/js/upload.js
+++ b/src/main/webapp/js/upload.js
@@ -54,9 +54,9 @@ async function uploadReceipt(event) {
 
   const json = (await response.json()).propertyMap;
   // Redirect to the receipt analysis page.
-  window.location.href = `/receipt-analysis.html?categories=${
-      json.categories}&image-url=${json.imageUrl}&price=${json.price}&store=${
-      json.store}&timestamp=${json.timestamp}`;
+  window.location.href = `/receipt-analysis.html?categories=` +
+      `${json.categories}&image-url=${json.imageUrl}` +
+      `&price=${json.price}&store=${json.store}&timestamp=${json.timestamp}`;
 }
 
 /**


### PR DESCRIPTION
- Instead of redirecting to the home page after a receipt is successfully uploaded, redirect to the receipt analysis page
- Send URL parameters containing information about the newly uploaded receipt so that the receipt analysis page can display it