### PR TITLE
Sanitize and format user-assigned categories stored in receipt entity.

### DIFF
--- a/src/main/java/servlets/UploadReceiptServlet.java
+++ b/src/main/java/servlets/UploadReceiptServlet.java
@@ -27,6 +27,7 @@ import com.google.appengine.api.datastore.Entity;
 import com.google.appengine.api.datastore.Text;
 import com.google.appengine.api.users.UserService;
 import com.google.appengine.api.users.UserServiceFactory;
+import com.google.common.collect.ImmutableSet;
 import com.google.sps.data.AnalysisResults;
 import com.google.sps.servlets.ReceiptAnalysis.ReceiptAnalysisException;
 import java.io.IOException;
@@ -279,13 +280,13 @@ public class UploadReceiptServlet extends HttpServlet {
   }
 
   /**
-   * Gets the list of user-assigned categories from the request.
+   * Gets the set of user-assigned categories from the request.
    */
-  private Set<String> getCategories(HttpServletRequest request) {
+  private ImmutableSet<String> getCategories(HttpServletRequest request) {
     return Arrays.asList(request.getParameterValues("categories"))
         .stream()
         .map(this::sanitize)
-        .collect(Collectors.toSet());
+        .collect(ImmutableSet.toImmutableSet());
   }
 
   /**

--- a/src/main/java/servlets/UploadReceiptServlet.java
+++ b/src/main/java/servlets/UploadReceiptServlet.java
@@ -36,7 +36,6 @@ import java.time.Clock;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -149,7 +148,6 @@ public class UploadReceiptServlet extends HttpServlet {
       throw new UserNotLoggedInException("User must be logged in to upload a receipt.");
     }
 
-    String label = request.getParameter("label");
     String userId = userService.getCurrentUser().getUserId();
 
     // Populate a receipt entity with the information extracted from the image with Cloud Vision.
@@ -284,7 +282,18 @@ public class UploadReceiptServlet extends HttpServlet {
    * Gets the list of user-assigned categories from the request.
    */
   private Set<String> getCategories(HttpServletRequest request) {
-    return new HashSet<>(Arrays.asList(request.getParameterValues("categories")));
+    return Arrays.asList(request.getParameterValues("categories"))
+        .stream()
+        .map(this::sanitize)
+        .collect(Collectors.toSet());
+  }
+
+  /**
+   * Converts the input to all lowercase with exactly 1 whitespace separating words and no leading
+   * or trailing whitespace.
+   */
+  private String sanitize(String input) {
+    return input.trim().replaceAll("\\s+", " ").toLowerCase();
   }
 
   public static class InvalidFileException extends Exception {

--- a/src/main/java/servlets/UploadReceiptServlet.java
+++ b/src/main/java/servlets/UploadReceiptServlet.java
@@ -36,9 +36,11 @@ import java.time.Clock;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -281,8 +283,8 @@ public class UploadReceiptServlet extends HttpServlet {
   /**
    * Gets the list of user-assigned categories from the request.
    */
-  private Collection<String> getCategories(HttpServletRequest request) {
-    return Arrays.asList(request.getParameterValues("categories"));
+  private Set<String> getCategories(HttpServletRequest request) {
+    return new HashSet<>(Arrays.asList(request.getParameterValues("categories")));
   }
 
   public static class InvalidFileException extends Exception {

--- a/src/main/java/servlets/UploadReceiptServlet.java
+++ b/src/main/java/servlets/UploadReceiptServlet.java
@@ -33,12 +33,16 @@ import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.time.Clock;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
@@ -150,7 +154,6 @@ public class UploadReceiptServlet extends HttpServlet {
     Entity receipt = analyzeReceiptImage(blobKey, request);
     receipt.setProperty("blobKey", blobKey);
     receipt.setProperty("timestamp", timestamp);
-    receipt.setProperty("label", label);
     receipt.setProperty("userId", userId);
 
     return receipt;
@@ -252,6 +255,8 @@ public class UploadReceiptServlet extends HttpServlet {
     receipt.setProperty("store", store);
     // Text objects wrap around a string of unlimited size while strings are limited to 1500 bytes.
     receipt.setUnindexedProperty("rawText", new Text(results.getRawText()));
+    // TODO: Add generated categories from Natural Language API.
+    receipt.setProperty("categories", getCategories(request));
 
     return receipt;
   }
@@ -271,6 +276,13 @@ public class UploadReceiptServlet extends HttpServlet {
         + request.getServerPort() + request.getContextPath();
 
     return baseUrl;
+  }
+
+  /**
+   * Gets the list of user-assigned categories from the request.
+   */
+  private Collection<String> getCategories(HttpServletRequest request) {
+    return Arrays.asList(request.getParameterValues("categories"));
   }
 
   public static class InvalidFileException extends Exception {

--- a/src/test/java/UploadReceiptServletTest.java
+++ b/src/test/java/UploadReceiptServletTest.java
@@ -259,8 +259,8 @@ public final class UploadReceiptServletTest {
     PreparedQuery results = datastore.prepare(query);
     Entity receipt = results.asSingleEntity();
 
-    Collection<String> categoriesWithoutDuplicates = Arrays.asList("lunch", "restaurant");
-    Assert.assertEquals(categoriesWithoutDuplicates, receipt.getProperty("categories"));
+    Collection<String> expectedCategories = Arrays.asList("lunch", "restaurant");
+    Assert.assertEquals(expectedCategories, receipt.getProperty("categories"));
   }
 
   @Test
@@ -285,9 +285,9 @@ public final class UploadReceiptServletTest {
     PreparedQuery results = datastore.prepare(query);
     Entity receipt = results.asSingleEntity();
 
-    Collection<String> formattedCategories =
+    Collection<String> expectedCategories =
         Arrays.asList("fast food", "burger", "restaurant", "lunch");
-    Assert.assertEquals(formattedCategories, receipt.getProperty("categories"));
+    Assert.assertEquals(expectedCategories, receipt.getProperty("categories"));
   }
 
   @Test

--- a/src/test/java/UploadReceiptServletTest.java
+++ b/src/test/java/UploadReceiptServletTest.java
@@ -260,7 +260,7 @@ public final class UploadReceiptServletTest {
     Entity receipt = results.asSingleEntity();
 
     Collection<String> categoriesWithoutDuplicates = Arrays.asList("lunch", "restaurant");
-    Assert.assertEquals(receipt.getProperty("categories"), categoriesWithoutDuplicates);
+    Assert.assertEquals(categoriesWithoutDuplicates, receipt.getProperty("categories"));
   }
 
   @Test
@@ -287,7 +287,7 @@ public final class UploadReceiptServletTest {
 
     Collection<String> formattedCategories =
         Arrays.asList("fast food", "burger", "restaurant", "lunch");
-    Assert.assertEquals(receipt.getProperty("categories"), formattedCategories);
+    Assert.assertEquals(formattedCategories, receipt.getProperty("categories"));
   }
 
   @Test

--- a/src/test/java/UploadReceiptServletTest.java
+++ b/src/test/java/UploadReceiptServletTest.java
@@ -50,7 +50,7 @@ import java.time.Instant;
 import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Calendar;
+import java.util.Collection;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -105,7 +105,8 @@ public final class UploadReceiptServletTest {
   private static final long IMAGE_SIZE_0MB = 0;
   private static final String HASH = "35454B055CC325EA1AF2126E27707052";
 
-  private static final String LABEL = "Label";
+  private static final String[] CATEGORIES = new String[] {"Fast Food, Burger, Restaurant"};
+  private static final Collection<String> CATEGORIES_COLLECTION = Arrays.asList(CATEGORIES);
   private static final Text RAW_TEXT = new Text("raw text");
   private static final double PRICE = 5.89;
   private static final String STORE = "McDonald's";
@@ -185,7 +186,7 @@ public final class UploadReceiptServletTest {
     helper.setEnvIsLoggedIn(true);
     createMockBlob(request, VALID_CONTENT_TYPE, VALID_FILENAME, IMAGE_SIZE_1MB);
 
-    when(request.getParameter("label")).thenReturn(LABEL);
+    when(request.getParameterValues("categories")).thenReturn(CATEGORIES);
     when(request.getParameter("date")).thenReturn(Long.toString(PAST_TIMESTAMP));
 
     // Stub request with URL components.
@@ -211,7 +212,7 @@ public final class UploadReceiptServletTest {
     Assert.assertEquals(receipt.getProperty("rawText"), RAW_TEXT);
     Assert.assertEquals(receipt.getProperty("blobKey"), BLOB_KEY);
     Assert.assertEquals(receipt.getProperty("timestamp"), PAST_TIMESTAMP);
-    Assert.assertEquals(receipt.getProperty("label"), LABEL);
+    Assert.assertEquals(receipt.getProperty("categories"), CATEGORIES_COLLECTION);
     Assert.assertEquals(receipt.getProperty("userId"), USER_ID);
   }
 
@@ -220,7 +221,7 @@ public final class UploadReceiptServletTest {
     helper.setEnvIsLoggedIn(true);
     createMockBlob(request, VALID_CONTENT_TYPE, VALID_FILENAME, IMAGE_SIZE_1MB);
 
-    when(request.getParameter("label")).thenReturn(LABEL);
+    when(request.getParameterValues("categories")).thenReturn(CATEGORIES);
     when(request.getParameter("date")).thenReturn(Long.toString(PAST_TIMESTAMP));
 
     // Stub request with dev server URL components.
@@ -244,8 +245,8 @@ public final class UploadReceiptServletTest {
     Assert.assertEquals(receipt.getProperty("store"), STORE);
     Assert.assertEquals(receipt.getProperty("rawText"), RAW_TEXT);
     Assert.assertEquals(receipt.getProperty("blobKey"), BLOB_KEY);
+    Assert.assertEquals(receipt.getProperty("categories"), CATEGORIES_COLLECTION);
     Assert.assertEquals(receipt.getProperty("timestamp"), PAST_TIMESTAMP);
-    Assert.assertEquals(receipt.getProperty("label"), LABEL);
     Assert.assertEquals(receipt.getProperty("userId"), USER_ID);
   }
 
@@ -371,7 +372,7 @@ public final class UploadReceiptServletTest {
     when(response.getWriter()).thenReturn(writer);
 
     createMockBlob(request, VALID_CONTENT_TYPE, VALID_FILENAME, IMAGE_SIZE_1MB);
-    when(request.getParameter("label")).thenReturn(LABEL);
+    when(request.getParameterValues("categories")).thenReturn(CATEGORIES);
     when(request.getParameter("date")).thenReturn(Long.toString(PAST_TIMESTAMP));
 
     // Stub request with URL components.


### PR DESCRIPTION
The search feature requires an exact match for categories, so this formats the categories stored in Datastore as in #34 (lowercase, leading and trailing spaces omitted, and only one space separating words).