### PR TITLE
Fix category form data.

### DIFF
--- a/src/main/webapp/js/upload.js
+++ b/src/main/webapp/js/upload.js
@@ -39,7 +39,9 @@ async function uploadReceipt(event) {
   const image = fileInput.files[0];
 
   const formData = new FormData();
-  formData.append('categories', createCategoryList(categories));
+  createCategoryList(categories).forEach((category) => {
+    formData.append('categories', category);
+  });
   formData.append('date', date);
   formData.append('receipt-image', image);
 


### PR DESCRIPTION
Getting the user-assigned categories from the upload servlet is implemented using `ServletRequest.getParameterValues()` (#41), which requires all category values to have the same key in the POST request body.