### PR TITLE
Sanitize and format store name stored in receipt entity.

### DIFF
--- a/src/main/java/servlets/UploadReceiptServlet.java
+++ b/src/main/java/servlets/UploadReceiptServlet.java
@@ -154,7 +154,7 @@ public class UploadReceiptServlet extends HttpServlet {
     receipt.setProperty("blobKey", blobKey);
     receipt.setProperty("timestamp", timestamp);
     receipt.setProperty("label", label);
-    receipt.setProperty("store", store);
+    receipt.setProperty("store", sanitize(store));
     receipt.setProperty("price", price);
     receipt.setProperty("userId", userId);
 
@@ -288,6 +288,14 @@ public class UploadReceiptServlet extends HttpServlet {
         + request.getServerPort() + request.getContextPath();
 
     return baseUrl;
+  }
+
+  /**
+   * Converts the input to all lowercase with exactly 1 whitespace separating words and no leading
+   * or trailing whitespace.
+   */
+  private String sanitize(String input) {
+    return input.trim().replaceAll("\\s+", " ").toLowerCase();
   }
 
   public static class InvalidFileException extends Exception {

--- a/src/test/java/UploadReceiptServletTest.java
+++ b/src/test/java/UploadReceiptServletTest.java
@@ -264,8 +264,8 @@ public final class UploadReceiptServletTest {
     PreparedQuery results = datastore.prepare(query);
     Entity receipt = results.asSingleEntity();
 
-    String formattedStore = "trader joe's";
-    Assert.assertEquals(receipt.getProperty("store"), formattedStore);
+    String expectedStore = "trader joe's";
+    Assert.assertEquals(receipt.getProperty("store"), expectedStore);
   }
 
   @Test


### PR DESCRIPTION
Similar to #41, the store name field in a receipt entity must also be formatted (lowercase, leading and trailing spaces omitted, and only one space separating words) to conform with the search implementation.