### PR TITLE
Add loading cursor and disable add receipt button after uploading a receipt.

### DIFF
--- a/src/main/webapp/js/upload.js
+++ b/src/main/webapp/js/upload.js
@@ -33,7 +33,10 @@ async function uploadReceipt(event) {
     return;
   }
 
-  const uploadUrl = fetchBlobstoreUrl();
+  // Change to the loading cursor.
+  document.body.style.cursor = 'wait';
+
+  const uploadUrl = await fetchBlobstoreUrl();
   const categories = document.getElementById('categories-input').value;
   const store = document.getElementById('store-input').value;
   const price =
@@ -49,6 +52,9 @@ async function uploadReceipt(event) {
   formData.append('receipt-image', image);
 
   const response = await fetch(uploadUrl, {method: 'POST', body: formData});
+
+  // Restore the cursor after the upload request has loaded.
+  document.body.style.cursor = 'default';
 
   // Create an alert if there is an error.
   if (response.status !== 200) {

--- a/src/main/webapp/js/upload.js
+++ b/src/main/webapp/js/upload.js
@@ -33,8 +33,9 @@ async function uploadReceipt(event) {
     return;
   }
 
-  // Change to the loading cursor.
+  // Change to the loading cursor and disable the submit button.
   document.body.style.cursor = 'wait';
+  document.getElementById('submit-receipt').disabled = true;
 
   const uploadUrl = await fetchBlobstoreUrl();
   const categories = document.getElementById('categories-input').value;


### PR DESCRIPTION
After the user submits the form on the upload page, there is a delay while the new receipt is processed and stored before the user is redirected to the receipt analysis page. During this time, the submit button should be disabled to prevent sending duplicate requests and a loading cursor should be displayed to indicate to the user that the receipt is being processed.