### PR TITLE
Re-enable add receipt button if an upload error occurs.

### DIFF
--- a/src/main/webapp/js/upload.js
+++ b/src/main/webapp/js/upload.js
@@ -35,7 +35,8 @@ async function uploadReceipt(event) {
 
   // Change to the loading cursor and disable the submit button.
   document.body.style.cursor = 'wait';
-  document.getElementById('submit-receipt').disabled = true;
+  const submitButton = document.getElementById('submit-receipt');
+  submitButton.disabled = true;
 
   const uploadUrl = await fetchBlobstoreUrl();
   const categories = document.getElementById('categories-input').value;
@@ -59,8 +60,9 @@ async function uploadReceipt(event) {
   // Restore the cursor after the upload request has loaded.
   document.body.style.cursor = 'default';
 
-  // Create an alert if there is an error.
+  // Create an alert and re-enable the submit button if there is an error.
   if (response.status !== 200) {
+    submitButton.disabled = false;
     alert(await response.text());
     return;
   }

--- a/src/main/webapp/js/upload.js
+++ b/src/main/webapp/js/upload.js
@@ -62,8 +62,8 @@ async function uploadReceipt(event) {
 
   // Create an alert and re-enable the submit button if there is an error.
   if (response.status !== 200) {
-    submitButton.disabled = false;
     alert(await response.text());
+    submitButton.disabled = false;
     return;
   }
 


### PR DESCRIPTION
Previously, a back-end error would cause the "Add Receipt" button to remain disabled, forcing the user to refresh the page which would reset the inputted fields.