### PR TITLE
Verify authentication in delete servlet.

### DIFF
--- a/src/main/java/servlets/DeleteReceiptServlet.java
+++ b/src/main/java/servlets/DeleteReceiptServlet.java
@@ -19,6 +19,8 @@ import com.google.appengine.api.datastore.DatastoreService;
 import com.google.appengine.api.datastore.DatastoreServiceFactory;
 import com.google.appengine.api.datastore.Key;
 import com.google.appengine.api.datastore.KeyFactory;
+import com.google.appengine.api.users.UserService;
+import com.google.appengine.api.users.UserServiceFactory;
 import java.io.IOException;
 import java.lang.NumberFormatException;
 import javax.servlet.annotation.WebServlet;
@@ -29,7 +31,11 @@ import javax.servlet.http.HttpServletResponse;
 /** Servlet responsible for deleting a single receipt. */
 @WebServlet("/delete-receipt")
 public class DeleteReceiptServlet extends HttpServlet {
+  private static final String NO_AUTHENTICATION_MESSAGE =
+      "No Authentication: User must be logged in to delete a receipt.";
+
   private final DatastoreService datastore;
+  private final UserService userService = UserServiceFactory.getUserService();
 
   public DeleteReceiptServlet() {
     datastore = DatastoreServiceFactory.getDatastoreService();
@@ -41,6 +47,12 @@ public class DeleteReceiptServlet extends HttpServlet {
 
   @Override
   public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    if (!userService.isUserLoggedIn()) {
+      response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+      response.getWriter().println(NO_AUTHENTICATION_MESSAGE);
+      return;
+    }
+
     long id = 0;
 
     try {


### PR DESCRIPTION
The user must be logged in with a Google account to delete a receipt.
- Ensure that the user is logged in before deleting a receipt in the delete servlet
- Add error message for lack of authentication