### PR TITLE
Make image URL and blob key unindexed properties.

### DIFF
--- a/src/main/java/servlets/UploadReceiptServlet.java
+++ b/src/main/java/servlets/UploadReceiptServlet.java
@@ -164,7 +164,7 @@ public class UploadReceiptServlet extends HttpServlet {
 
     // Populate a receipt entity with the information extracted from the image with Cloud Vision.
     Entity receipt = analyzeReceiptImage(blobKey, request);
-    receipt.setProperty("blobKey", blobKey);
+    receipt.setUnindexedProperty("blobKey", blobKey);
     receipt.setProperty("timestamp", timestamp);
     receipt.setProperty("store", sanitize(store));
     receipt.setProperty("price", price);
@@ -278,7 +278,7 @@ public class UploadReceiptServlet extends HttpServlet {
 
     // Create an entity with a kind of Receipt.
     Entity receipt = new Entity("Receipt");
-    receipt.setProperty("imageUrl", imageUrl);
+    receipt.setUnindexedProperty("imageUrl", imageUrl);
     // Text objects wrap around a string of unlimited size while strings are limited to 1500 bytes.
     receipt.setUnindexedProperty("rawText", new Text(results.getRawText()));
     // TODO: Add generated categories from Natural Language API.

--- a/src/test/java/UploadReceiptServletTest.java
+++ b/src/test/java/UploadReceiptServletTest.java
@@ -535,10 +535,10 @@ public final class UploadReceiptServletTest {
   private String createReceiptEntity(String imageUrl, double price, String store, Text rawText,
       BlobKey blobKey, long timestamp, Collection<String> categories, String userId) {
     Entity receipt = new Entity("Receipt");
-    receipt.setProperty("imageUrl", imageUrl);
+    receipt.setUnindexedProperty("imageUrl", imageUrl);
     receipt.setUnindexedProperty("rawText", rawText);
     receipt.setProperty("categories", categories);
-    receipt.setProperty("blobKey", blobKey);
+    receipt.setUnindexedProperty("blobKey", blobKey);
     receipt.setProperty("timestamp", timestamp);
     receipt.setProperty("store", store);
     receipt.setProperty("price", price);


### PR DESCRIPTION
Since no filtering or sorting will be done on the image URL or blob key properties, they do not need to be indexed in Datastore.