### PR TITLE
Fix redirection from login page to home page for a logged-in user.

### DIFF
--- a/src/main/webapp/css/login.css
+++ b/src/main/webapp/css/login.css
@@ -1,5 +1,6 @@
 body {
   background: azure;
+  display: none;
 }
 
 h1 {

--- a/src/main/webapp/css/login.css
+++ b/src/main/webapp/css/login.css
@@ -1,6 +1,5 @@
 body {
   background: azure;
-  display: none;
 }
 
 h1 {

--- a/src/main/webapp/js/login.js
+++ b/src/main/webapp/js/login.js
@@ -14,4 +14,6 @@ async function getLoginUrl() {
 
   const loginLink = document.getElementById('login-link');
   loginLink.href = json.loginUrl;
+
+  document.body.style.display = 'block';
 }


### PR DESCRIPTION
Same as #63, but addresses a logged-in user getting redirected from the login page to the home page.
- Hides the login page body by default
- Displays the body only if the user is logged out