### PR TITLE
Fix redirection from receipt analysis page to login page for a logged-out user.

### DIFF
--- a/src/main/webapp/css/receipt-analysis.css
+++ b/src/main/webapp/css/receipt-analysis.css
@@ -1,3 +1,7 @@
+body {
+  display: none;
+}
+
 .card {
   max-width: 600px;
 }

--- a/src/main/webapp/css/receipt-analysis.css
+++ b/src/main/webapp/css/receipt-analysis.css
@@ -1,7 +1,3 @@
-body {
-  display: none;
-}
-
 .card {
   max-width: 600px;
 }

--- a/src/main/webapp/js/index.js
+++ b/src/main/webapp/js/index.js
@@ -17,7 +17,7 @@
  */
 function load() {
   /* global loadPage */
-  loadPage(getAllReceipts, loadLogoutButton);
+  loadPage(getAllReceipts, loadLogoutButton);  // From js/script.js
 }
 
 /**

--- a/src/main/webapp/js/receipt-analysis.js
+++ b/src/main/webapp/js/receipt-analysis.js
@@ -18,7 +18,7 @@
  */
 function load() {
   /* global loadPage */
-  loadPage(loadReceiptAnalysis);
+  loadPage(loadReceiptAnalysis);  // From js/script.js.
 }
 
 /** Fetches receipt properties from the server and adds them to the page. */

--- a/src/main/webapp/js/receipt-analysis.js
+++ b/src/main/webapp/js/receipt-analysis.js
@@ -16,31 +16,9 @@
  * Loads the page if the user is logged in. Otherwise, redirects to the
  * login page.
  */
-async function loadPage() {
-  const loggedIn = await checkAuthentication();
-
-  if (loggedIn) {
-    document.body.style.display = 'block';
-    loadReceiptAnalysis();
-  }
-}
-
-/**
- * Fetches the login status and redirects to the login page if the user is
- * logged out.
- * @return {boolean} Whether the user is logged in or not.
- */
-async function checkAuthentication() {
-  const response = await fetch('/login-status');
-  const account = await response.json();
-
-  // Redirect to the login page if the user is not logged in.
-  if (!account.loggedIn) {
-    window.location.replace('/login.html');
-    return false;
-  }
-
-  return true;
+function load() {
+  /* global loadPage */
+  loadPage(loadReceiptAnalysis);
 }
 
 /** Fetches receipt properties from the server and adds them to the page. */

--- a/src/main/webapp/js/receipt-analysis.js
+++ b/src/main/webapp/js/receipt-analysis.js
@@ -12,6 +12,37 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+/**
+ * Loads the page if the user is logged in. Otherwise, redirects to the
+ * login page.
+ */
+async function loadPage() {
+  const loggedIn = await checkAuthentication();
+
+  if (loggedIn) {
+    document.body.style.display = 'block';
+    loadReceiptAnalysis();
+  }
+}
+
+/**
+ * Fetches the login status and redirects to the login page if the user is
+ * logged out.
+ * @return {boolean} Whether the user is logged in or not.
+ */
+async function checkAuthentication() {
+  const response = await fetch('/login-status');
+  const account = await response.json();
+
+  // Redirect to the login page if the user is not logged in.
+  if (!account.loggedIn) {
+    window.location.replace('/login.html');
+    return false;
+  }
+
+  return true;
+}
+
 /** Fetches receipt properties from the server and adds them to the page. */
 function loadReceiptAnalysis() {
   const parameters = new URLSearchParams(location.search);

--- a/src/main/webapp/receipt-analysis.html
+++ b/src/main/webapp/receipt-analysis.html
@@ -16,11 +16,12 @@
 <link rel="stylesheet" href="css/style.css" />
 <link rel="stylesheet" href="css/receipt-analysis.css" />
 
+<script src="js/script.js"></script>
 <script src="js/receipt-analysis.js"></script>
 
 <title>Receipt Analysis</title>
 
-<body onload="loadPage()">
+<body onload="load()">
   <h1 class="p-3 text-center">Receipt Analysis</h1>
 
   <div class="container-fluid">

--- a/src/main/webapp/receipt-analysis.html
+++ b/src/main/webapp/receipt-analysis.html
@@ -20,7 +20,7 @@
 
 <title>Receipt Analysis</title>
 
-<body onload="loadReceiptAnalysis()">
+<body onload="loadPage()">
   <h1 class="p-3 text-center">Receipt Analysis</h1>
 
   <div class="container-fluid">


### PR DESCRIPTION
Similar to #63, but for the receipt analysis page.
- Hides the receipt analysis page body by default
- Adds onload event handler to display body only if the user is logged in