### PR TITLE
Add store from detected logo to receipt entity.

### DIFF
--- a/src/main/java/servlets/UploadReceiptServlet.java
+++ b/src/main/java/servlets/UploadReceiptServlet.java
@@ -166,9 +166,8 @@ public class UploadReceiptServlet extends HttpServlet {
     // Populate a receipt entity with the information extracted from the image with Cloud Vision.
     Entity receipt = analyzeReceiptImage(blobKey, request);
     receipt.setUnindexedProperty("blobKey", blobKey);
-    // TODO: Use store, price, and timestamp from receipt analysis and parsing.
+    // TODO: Use price and timestamp from receipt parsing.
     receipt.setProperty("timestamp", timestamp);
-    receipt.setProperty("store", sanitize(store));
     receipt.setProperty("price", price);
     receipt.setProperty("userId", userId);
 
@@ -284,6 +283,8 @@ public class UploadReceiptServlet extends HttpServlet {
     // Text objects wrap around a string of unlimited size while strings are limited to 1500 bytes.
     receipt.setUnindexedProperty("rawText", new Text(results.getRawText()));
     receipt.setProperty("categories", getCategories(request, results.getCategories()));
+    // If a logo was detected, set the store name.
+    results.getStore().ifPresent(store -> { receipt.setProperty("store", sanitize(store)); });
 
     return receipt;
   }


### PR DESCRIPTION
#74 uses logo detection to add a store property to `AnalysisResults`, which is now used to set the store property of a newly uploaded receipt instead of the request body parameter from the upload page.