### PR TITLE
Add receipt ID field to receipt analysis page query string.

### DIFF
--- a/src/main/webapp/js/upload.js
+++ b/src/main/webapp/js/upload.js
@@ -68,13 +68,15 @@ async function uploadReceipt(event) {
     return;
   }
 
-  const json = (await response.json()).propertyMap;
+  const json = (await response.json());
+  const receipt = json.propertyMap;
   const params = new URLSearchParams();
-  params.append('categories', json.categories);
-  params.append('image-url', json.imageUrl);
-  params.append('price', json.price);
-  params.append('store', json.store);
-  params.append('timestamp', json.timestamp);
+  params.append('id', json.key.id);
+  params.append('categories', receipt.categories);
+  params.append('image-url', receipt.imageUrl);
+  params.append('price', receipt.price);
+  params.append('store', receipt.store);
+  params.append('timestamp', receipt.timestamp);
 
   // Redirect to the receipt analysis page.
   window.location.href = `/receipt-analysis.html?${params.toString()}`;


### PR DESCRIPTION
In order to make a request to the edit servlet, the receipt analysis page must include an ID for the receipt entity in the request body. 

- Adds the ID to the query string when the upload page redirects to the receipt analysis page 