### PR TITLE
Refactor setting the timestamp property in the upload servlet.

### DIFF
--- a/src/main/java/servlets/UploadReceiptServlet.java
+++ b/src/main/java/servlets/UploadReceiptServlet.java
@@ -154,7 +154,6 @@ public class UploadReceiptServlet extends HttpServlet {
   private Entity createReceiptEntity(HttpServletRequest request)
       throws FileNotSelectedException, InvalidFileException, UserNotLoggedInException,
              InvalidPriceException, InvalidDateException, ReceiptAnalysisException {
-    long timestamp = FormatUtils.getTimestamp(request, this.clock);
     BlobKey blobKey = getUploadedBlobKey(request, "receipt-image");
 
     if (!userService.isUserLoggedIn()) {
@@ -168,7 +167,6 @@ public class UploadReceiptServlet extends HttpServlet {
     // Populate a receipt entity with the information extracted from the image with Cloud Vision.
     Entity receipt = analyzeReceiptImage(blobKey, request);
     receipt.setUnindexedProperty("blobKey", blobKey);
-    receipt.setProperty("timestamp", timestamp);
     receipt.setProperty("store", FormatUtils.sanitize(store));
     receipt.setProperty("userId", userId);
 
@@ -219,7 +217,7 @@ public class UploadReceiptServlet extends HttpServlet {
    * entity populated with the extracted fields.
    */
   private Entity analyzeReceiptImage(BlobKey blobKey, HttpServletRequest request)
-      throws ReceiptAnalysisException, InvalidPriceException {
+      throws ReceiptAnalysisException, InvalidPriceException, InvalidDateException {
     String imageUrl = getBlobServingUrl(blobKey);
     String baseUrl = getBaseUrl(request);
 
@@ -242,7 +240,8 @@ public class UploadReceiptServlet extends HttpServlet {
     // Create an entity with a kind of Receipt.
     Entity receipt = new Entity("Receipt");
     receipt.setUnindexedProperty("imageUrl", imageUrl);
-    // TODO: Replace with parsed price.
+    // TODO: Replace with parsed price and timestamp.
+    receipt.setProperty("timestamp", FormatUtils.getTimestamp(request, this.clock));
     receipt.setProperty("price", FormatUtils.roundPrice(request.getParameter("price")));
     // Text objects wrap around a string of unlimited size while strings are limited to 1500 bytes.
     receipt.setUnindexedProperty("rawText", new Text(results.getRawText()));

--- a/src/test/java/UploadReceiptServletTest.java
+++ b/src/test/java/UploadReceiptServletTest.java
@@ -377,7 +377,6 @@ public final class UploadReceiptServletTest {
     helper.setEnvIsLoggedIn(true);
 
     createMockBlob(request, VALID_CONTENT_TYPE, VALID_FILENAME, IMAGE_SIZE_0MB);
-    stubRequestBody(request, USER_CATEGORIES, STORE, PRICE, PAST_TIMESTAMP);
 
     servlet.doPost(request, response);
     writer.flush();
@@ -395,8 +394,6 @@ public final class UploadReceiptServletTest {
     Map<String, List<BlobKey>> blobs = new HashMap<>();
     when(blobstoreService.getUploads(request)).thenReturn(blobs);
 
-    stubRequestBody(request, USER_CATEGORIES, STORE, PRICE, PAST_TIMESTAMP);
-
     servlet.doPost(request, response);
     writer.flush();
 
@@ -409,7 +406,6 @@ public final class UploadReceiptServletTest {
     helper.setEnvIsLoggedIn(true);
 
     createMockBlob(request, INVALID_CONTENT_TYPE, INVALID_FILENAME, IMAGE_SIZE_1MB);
-    stubRequestBody(request, USER_CATEGORIES, STORE, PRICE, PAST_TIMESTAMP);
 
     servlet.doPost(request, response);
     writer.flush();
@@ -438,9 +434,9 @@ public final class UploadReceiptServletTest {
   public void doPostThrowsIfDateIsInTheFuture() throws IOException, ReceiptAnalysisException {
     helper.setEnvIsLoggedIn(true);
 
-    long futureTimestamp = Instant.parse(INSTANT).plusMillis(1234).toEpochMilli();
     createMockBlob(request, VALID_CONTENT_TYPE, VALID_FILENAME, IMAGE_SIZE_1MB);
-    stubRequestBody(request, USER_CATEGORIES, STORE, PRICE, futureTimestamp);
+    long futureTimestamp = Instant.parse(INSTANT).plusMillis(1234).toEpochMilli();
+    when(request.getParameter("date")).thenReturn(Long.toString(futureTimestamp));
     stubUrlComponents(
         request, LIVE_SERVER_SCHEME, LIVE_SERVER_NAME, LIVE_SERVER_PORT, LIVE_SERVER_CONTEXT_PATH);
 
@@ -483,7 +479,6 @@ public final class UploadReceiptServletTest {
     helper.setEnvIsLoggedIn(true);
 
     createMockBlob(request, VALID_CONTENT_TYPE, VALID_FILENAME, IMAGE_SIZE_1MB);
-    stubRequestBody(request, USER_CATEGORIES, STORE, PRICE, PAST_TIMESTAMP);
     stubUrlComponents(
         request, LIVE_SERVER_SCHEME, LIVE_SERVER_NAME, LIVE_SERVER_PORT, LIVE_SERVER_CONTEXT_PATH);
 

--- a/src/test/java/UploadReceiptServletTest.java
+++ b/src/test/java/UploadReceiptServletTest.java
@@ -505,10 +505,6 @@ public final class UploadReceiptServletTest {
   public void doPostRoundPrice() throws IOException, ReceiptAnalysisException {
     helper.setEnvIsLoggedIn(true);
 
-    StringWriter stringWriter = new StringWriter();
-    PrintWriter writer = new PrintWriter(stringWriter);
-    when(response.getWriter()).thenReturn(writer);
-
     createMockBlob(request, VALID_CONTENT_TYPE, VALID_FILENAME, IMAGE_SIZE_1MB);
 
     double price = 17.236;
@@ -535,10 +531,6 @@ public final class UploadReceiptServletTest {
   public void doPostThrowsIfPriceNotParsable() throws IOException, ReceiptAnalysisException {
     helper.setEnvIsLoggedIn(true);
 
-    StringWriter stringWriter = new StringWriter();
-    PrintWriter writer = new PrintWriter(stringWriter);
-    when(response.getWriter()).thenReturn(writer);
-
     createMockBlob(request, VALID_CONTENT_TYPE, VALID_FILENAME, IMAGE_SIZE_1MB);
     stubUrlComponents(
         request, LIVE_SERVER_SCHEME, LIVE_SERVER_NAME, LIVE_SERVER_PORT, LIVE_SERVER_CONTEXT_PATH);
@@ -562,10 +554,6 @@ public final class UploadReceiptServletTest {
   @Test
   public void doPostThrowsIfPriceNegative() throws IOException, ReceiptAnalysisException {
     helper.setEnvIsLoggedIn(true);
-
-    StringWriter stringWriter = new StringWriter();
-    PrintWriter writer = new PrintWriter(stringWriter);
-    when(response.getWriter()).thenReturn(writer);
 
     createMockBlob(request, VALID_CONTENT_TYPE, VALID_FILENAME, IMAGE_SIZE_1MB);
     stubUrlComponents(


### PR DESCRIPTION
When the user-assigned transaction date is replaced by the parsed date, the date property of the entity will need to be set after the receipt analysis is completed, which occurs in the `analyzeReceiptImage()` method.