### PR TITLE
Remove category input from upload page.

### DIFF
--- a/src/main/webapp/css/upload.css
+++ b/src/main/webapp/css/upload.css
@@ -72,11 +72,6 @@ small {
     padding: 1.5%;
   }
 
-  #categories-input {
-    font-size: 20px;
-    width: 20em;
-  }
-
   .custom-file {
     height: 1rem;
   }

--- a/src/main/webapp/js/upload.js
+++ b/src/main/webapp/js/upload.js
@@ -47,13 +47,9 @@ async function uploadReceipt(event) {
   submitButton.disabled = true;
 
   const uploadUrl = await fetchBlobstoreUrl();
-  const categories = document.getElementById('categories-input').value;
   const image = fileInput.files[0];
 
   const formData = new FormData();
-  createCategoryList(categories).forEach((category) => {
-    formData.append('categories', category);
-  });
   formData.append('receipt-image', image);
 
   const response = await fetch(uploadUrl, {method: 'POST', body: formData});
@@ -88,14 +84,6 @@ async function fetchBlobstoreUrl() {
   const response = await fetch('/upload-receipt');
   const imageUploadUrl = await response.text();
   return imageUploadUrl;
-}
-
-/**
- * Converts the comma-separated categories string into a list of categories.
- * @return {(string|Array)} List of categories.
- */
-function createCategoryList(categories) {
-  return categories.split(',').map((category) => category.trim());
 }
 
 /**

--- a/src/main/webapp/upload.html
+++ b/src/main/webapp/upload.html
@@ -23,16 +23,6 @@
   <br />
 
   <form id="upload-form" action="#" onsubmit="uploadReceipt(event)">
-    <label for="label">Enter tags for the receipt:</label>
-    <input
-      id="categories-input"
-      class="form-control"
-      type="text"
-      name="label"
-      placeholder="Category 1, Category 2, Category 3"
-      required
-    />
-
     <label id="receipt-image-label" for="receipt-image-input">Upload a receipt image:</label>
     <div class="custom-file">
       <input


### PR DESCRIPTION
The category input field will initially be generated by the Natural Language API during receipt analysis and then be made editable on the receipt analysis page, where the user will be able to add their own categories.
![upload](https://user-images.githubusercontent.com/38800607/88438935-cbdad380-cdd7-11ea-9808-bf7850c0dad9.png)
