### PR TITLE
Remove user-assigned categories from upload servlet.

### DIFF
--- a/src/main/java/servlets/EditReceiptServlet.java
+++ b/src/main/java/servlets/EditReceiptServlet.java
@@ -114,20 +114,11 @@ public class EditReceiptServlet extends HttpServlet {
     double price = FormatUtils.roundPrice(request.getParameter("price"));
     long timestamp = FormatUtils.getTimestamp(request, clock);
 
-    receipt.setProperty("categories", getCategories(request));
+    receipt.setProperty("categories", FormatUtils.getCategories(request));
     receipt.setProperty("store", store);
     receipt.setProperty("price", price);
     receipt.setProperty("timestamp", timestamp);
 
     return receipt;
-  }
-
-  /**
-   * Sanitizes and formats the set of categories from the request.
-   */
-  private ImmutableSet<String> getCategories(HttpServletRequest request) {
-    return Arrays.stream(request.getParameterValues("categories"))
-        .map(FormatUtils::sanitize)
-        .collect(ImmutableSet.toImmutableSet());
   }
 }

--- a/src/main/java/servlets/FormatUtils.java
+++ b/src/main/java/servlets/FormatUtils.java
@@ -14,7 +14,10 @@
 
 package com.google.sps.servlets;
 
+import com.google.common.collect.ImmutableSet;
 import java.time.Clock;
+import java.util.Arrays;
+import java.util.stream.Stream;
 import javax.servlet.http.HttpServletRequest;
 
 /**
@@ -26,6 +29,20 @@ public final class FormatUtils {
    */
   private FormatUtils() {
     throw new UnsupportedOperationException();
+  }
+
+  /**
+   * Sanitizes and formats the set of categories from the request.
+   */
+  public static ImmutableSet<String> getCategories(HttpServletRequest request) {
+    return sanitizeCategories(Arrays.stream(request.getParameterValues("categories")));
+  }
+
+  /**
+   * Sanitizes and formats the given stream of categories.
+   */
+  public static ImmutableSet<String> sanitizeCategories(Stream<String> categories) {
+    return categories.map(FormatUtils::sanitize).collect(ImmutableSet.toImmutableSet());
   }
 
   /**

--- a/src/main/java/servlets/UploadReceiptServlet.java
+++ b/src/main/java/servlets/UploadReceiptServlet.java
@@ -247,7 +247,8 @@ public class UploadReceiptServlet extends HttpServlet {
     receipt.setUnindexedProperty("imageUrl", imageUrl);
     // Text objects wrap around a string of unlimited size while strings are limited to 1500 bytes.
     receipt.setUnindexedProperty("rawText", new Text(results.getRawText()));
-    receipt.setProperty("categories", getCategories(request, results.getCategories()));
+    receipt.setProperty(
+        "categories", FormatUtils.sanitizeCategories(results.getCategories().stream()));
 
     return receipt;
   }
@@ -267,19 +268,6 @@ public class UploadReceiptServlet extends HttpServlet {
         + request.getServerPort() + request.getContextPath();
 
     return baseUrl;
-  }
-
-  /**
-   * Gets the set of both user-assigned categories from the request and generated categories from
-   * the receipt analysis.
-   */
-  private ImmutableSet<String> getCategories(
-      HttpServletRequest request, Set<String> generatedCategories) {
-    return Stream
-        .concat(
-            Arrays.stream(request.getParameterValues("categories")), generatedCategories.stream())
-        .map(FormatUtils::sanitize)
-        .collect(ImmutableSet.toImmutableSet());
   }
 
   public static class InvalidFileException extends Exception {


### PR DESCRIPTION
User-assigned categories can now only be set by editing the receipt. The initial upload only includes categories that were generated from the Natural Language API.
- Removes user-assigned categories from upload servlet
- Moves category formatting methods to `FormatUtils` class