### PR TITLE
Increase image size limit to 10 MB.

### DIFF
--- a/src/main/java/servlets/UploadReceiptServlet.java
+++ b/src/main/java/servlets/UploadReceiptServlet.java
@@ -55,8 +55,8 @@ import javax.servlet.http.HttpServletResponse;
  */
 @WebServlet("/upload-receipt")
 public class UploadReceiptServlet extends HttpServlet {
-  // Max upload size of 5 MB.
-  private static final long MAX_UPLOAD_SIZE_BYTES = 5 * 1024 * 1024;
+  // Max upload size of 10 MB.
+  private static final long MAX_UPLOAD_SIZE_BYTES = 10 * 1024 * 1024;
   // Base URL for the web app running on the Cloud Shell dev server.
   private static final String DEV_SERVER_BASE_URL = "http://0.0.0.0:80";
   // Matches JPEG image filenames.

--- a/src/main/webapp/js/upload.js
+++ b/src/main/webapp/js/upload.js
@@ -106,12 +106,12 @@ function displayFileName() {
 }
 
 /**
- * Displays an error message if the user selects a file larger than 5 MB.
- * @return {boolean} Whether a file is selected and has size less than 5 MB.
+ * Displays an error message if the user selects a file larger than 10 MB.
+ * @return {boolean} Whether a file is selected and has size less than 10 MB.
  */
 function checkFileSize() {
   const fileInput = document.getElementById('receipt-image-input');
-  const MAX_FILE_SIZE_BYTES = 5 * 1024 * 1024;
+  const MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024;
 
   // Return if the user did not select a file.
   if (fileInput.files.length === 0) {
@@ -119,7 +119,7 @@ function checkFileSize() {
   }
 
   if (fileInput.files[0].size > MAX_FILE_SIZE_BYTES) {
-    alert('The selected file exceeds the maximum file size of 5 MB.');
+    alert('The selected file exceeds the maximum file size of 10 MB.');
     fileInput.value = '';
     return false;
   }

--- a/src/main/webapp/upload.html
+++ b/src/main/webapp/upload.html
@@ -35,7 +35,7 @@
       />
       <label id="receipt-filename-label" class="custom-file-label" for="receipt-image-input">Choose file</label>
     </div>
-    <small class="form-text text-muted">Only JPEG images under 5 MB are accepted.</small>
+    <small class="form-text text-muted">Only JPEG images under 10 MB are accepted.</small>
     <br />
 
     <button id="submit-receipt" class="btn btn-lg btn-primary" type="submit">Add Receipt</button>

--- a/src/test/java/UploadReceiptServletTest.java
+++ b/src/test/java/UploadReceiptServletTest.java
@@ -98,7 +98,7 @@ public final class UploadReceiptServletTest {
   private static final long PAST_TIMESTAMP =
       Instant.parse(INSTANT).minusMillis(1234).toEpochMilli();
 
-  private static final long MAX_UPLOAD_SIZE_BYTES = 5 * 1024 * 1024;
+  private static final long MAX_UPLOAD_SIZE_BYTES = 10 * 1024 * 1024;
   private static final String UPLOAD_URL = "/blobstore/upload-receipt";
 
   private static final BlobKey BLOB_KEY = new BlobKey("blobKey");


### PR DESCRIPTION
Allows for phones with larger image sizes to be able to upload receipt images.